### PR TITLE
Removed a useless blank

### DIFF
--- a/resources/views/panels/document.blade.php
+++ b/resources/views/panels/document.blade.php
@@ -256,11 +256,11 @@
 				@if($item->owner->organization_name)
 					@if($item->owner->organization_website)
 
-						(<a href="{{$item->owner->organization_website}}">{{ $item->owner->organization_name }}</a>)
+						(<a href="{{$item->owner->organization_website}}">{{ $item->owner->organization_name}}</a>)
 
 					@else
 
-						({{ $item->owner->organization_name }})
+						({{ $item->owner->organization_name}})
 
 					@endif
 				@endif


### PR DESCRIPTION
Removed a useless blank between the name of the institution and the closing ')' 

Patch for https://github.com/k-box/k-box/issues/59